### PR TITLE
small fix

### DIFF
--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -76,11 +76,11 @@
 				prefix: "jQuery.each($1,function($2){with(this){",
 				suffix: "}});"
 			},
-			if: {
+			'if': {
 				prefix: "if($1){",
 				suffix: "}"
 			},
-			else: {
+			'else': {
 				prefix: "}else{"
 			},
 			html: {


### PR DESCRIPTION
Loading into Google Chrome with if and else used as bare words in jquery.tmpl.js causes syntax error.
quoting them fixes it.
