### PR TITLE
adds $index property to nested templates

### DIFF
--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -144,7 +144,8 @@
 				updateWrapped( options, options.wrapped );
 			}
 			ret = jQuery.isArray( data ) ? 
-				jQuery.map( data, function( dataItem ) {
+				jQuery.map( data, function( dataItem, index ) {
+					if(dataItem){dataItem.$index = index;}
 					return dataItem ? newTmplItem( options, parentItem, tmpl, dataItem ) : null;
 				}) :
 				[ newTmplItem( options, parentItem, tmpl, data ) ];


### PR DESCRIPTION
(similar to the each tag) adds an "$index" property to the data item passed to nested templates using the {{tmpl}} tag
fixes: https://github.com/jquery/jquery-tmpl/issues#issue/28
