### PR TITLE
Ajax implementation for getting remote templates

### DIFF
--- a/demos/samplesCore/ajax.html
+++ b/demos/samplesCore/ajax.html
@@ -1,0 +1,11 @@
+<script src="http://code.jquery.com/jquery-git.js"></script>
+<script src="../../jquery.tmpl.js" type="text/javascript"></script>
+
+<script>
+jQuery.getTemplate('http://localhost/template.jqtpl', 'hello', function(template) {
+	jQuery.tmpl(template, {name: 'Daniel'}).appendTo('div');
+});
+</script>
+
+<div>
+</div>

--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -267,6 +267,32 @@
 		}
 	});
 
+	// Add getTemplate function to jQuery
+	// It takes an url to the template file, a name for the 
+	// template and a callback that is called as soon as the
+	// template was fetched and compiled.
+	jQuery.extend(true, jQuery, {
+		getTemplate: function(url, name, callback) {
+			return jQuery.ajax({type: 'get', url: url, data: null, success: callback, dataType: "template", templateName: name});
+		}
+	});
+	
+	jQuery.ajaxSetup({
+		accepts: {
+			template: 'text/x-jquery-tmpl'
+		},
+		contents: {
+			template: /tmpl/
+		}
+	});
+	
+	jQuery.ajaxPrefilter( "template", function(s) {
+		s.converters['text template'] = function (text) {
+			jQuery.template( s.templateName, text );
+			return s.templateName;
+		}
+	});
+	
 	//========================== Private helper functions, used by code above ==========================
 
 	function build( tmplItem, nested, content ) {


### PR DESCRIPTION
I implemented a getTemplate and the suiting $.ajax({dataType:"template"}) parameter which enables easy template fetching from a remote host. It utilizes the new ajax interface of jQuery 1.5. This however means it requires jQuery 1.5 to function, so you will propably not want to pull it in before starting any jQuery 1.5 based work. I also added an example you might want to check out. However, it's really trivial:

```
jQuery.getTemplate('/url/to/template', 'nameCompiledTemplateWillGet', function (templateName) {
  // you now have the name of your compiled template in templateNane and can use it, eg:
  jQuery.tmpl(templateName, { replaceMe: 'You where replaced!' }).appendTo('#hook');
}
```

Maybe it would be nice to actually get the jQuery wrapped compiled template instead of the name, wasn't sure on that.

Best regards,
Daniel
