### PR TITLE
'with' statement in template function conflicts with other variables and DOM elements

### DIFF
--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -219,8 +219,8 @@
 			},
 			"each": {
 				_default: { $2: "$index, $value" },
-				open: "if($notnull_1){$.each($1a,function($2){with(this){",
-				close: "}});}"
+				open: "if($notnull_1){$.each($1a,function($2){var $dataSaved=$data;$data=this;",
+				close: "$data=$dataSaved;});}"
 			},
 			"if": {
 				open: "if(($notnull_1) && $1a){",


### PR DESCRIPTION
This update removes the with($data){ } block and instead prepends $data. in front of any render of the target property name.

In Chrome, the 'with' implementation was able to pull elements from the DOM instead of leaving the field blank if the replacement field in the template was named the same as another DOM element and there is no matching property name on the object passed into the tmpl method.
