### PR TITLE
Allow template variable without HTML tags to be used in {{tmpl}}

### DIFF
--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -194,7 +194,7 @@
 			return name ? (typeof name !== "string" ? jQuery.template( null, name ): 
 				(jQuery.template[name] || 
 					// If not in map, treat as a selector. (If integrated with core, use quickExpr.exec) 
-					jQuery.template( null, htmlExpr.test( name ) ? name : jQuery( name )))) : null; 
+					jQuery.template( null, jQuery( name )[0] ? jQuery( name ) : name))) : null; 
 		},
 
 		encode: function( text ) {


### PR DESCRIPTION
Trying to fix the problem here: https://github.com/jquery/jquery-tmpl/issues#issue/69

In jQuery.template, changed the tests of the name parameter to check whether it can be used as a selector first, and if not, use it as-is. Previously it appeared that the htmlExpr test would only accept it if it contained HTML tags, and didn't work for short snippets of text.

Before:
    return name ? (typeof name !== "string" ? jQuery.template( null, name ): 
                (jQuery.template[name] || 
                    // If not in map, treat as a selector. (If integrated with core, use quickExpr.exec) 
                    jQuery.template( null, htmlExpr.test( name ) ? name : jQuery( name )))) : null; 

After:
    return name ? (typeof name !== "string" ? jQuery.template( null, name ): 
                (jQuery.template[name] || 
                    // If not in map, treat as a selector. (If integrated with core, use quickExpr.exec) 
                    jQuery.template( null, jQuery( name )[0] ? jQuery( name ) : name))) : null;
