### PR TITLE
Add "set" tag with syntax {{set(variable) value}} to set variable without affecting template output

### DIFF
--- a/jquery.tmpl.js
+++ b/jquery.tmpl.js
@@ -218,6 +218,10 @@
 				open: "$item.calls(__,$1,$2);__=[];",
 				close: "call=$item.calls();__=call._.concat($item.wrap(call,__));"
 			},
+			"set": {
+				_default: { $2: "$data" },
+				open: "$2=$1a;"
+			},
 			"each": {
 				_default: { $2: "$index, $value" },
 				open: "if($notnull_1){$.each($1a,function($2){with(this){",


### PR DESCRIPTION
This functionality is present in at least the Tornado template engine; I'm sure there are others.  This syntax is quite non-standard, but I was hesitant to add a new construct to jQuery Templates myself.  Current workaround is `${variable = value, ''}`, which requires above-beginner Javascript knowledge to guess.
